### PR TITLE
updating actions/cache github action as v2 is being deprecated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       with:
         java-version: 11
     - name: Cache Maven packages
-      uses: actions/cache@v2
+      uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
**JIRA Ticket**: https://fedora-repository.atlassian.net/browse/FCREPO-3966

# What does this Pull Request do?
bumps actions/cache in GH workflow from 2 to 4 

# How should this be tested?
Check actions still run. They should as this is backwards compatible 

# Interested parties
Tag (@ mention) interested parties or, if unsure, @fcrepo/committers
